### PR TITLE
Fix LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2017 IBM Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Previously, our LICENSE did not have the boilerplate section filled out.
Now, the boilerplate section has the correct information.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>